### PR TITLE
Handle KeyError exception in TogglReportsClient.projects method

### DIFF
--- a/toggl2pl/__init__.py
+++ b/toggl2pl/__init__.py
@@ -581,16 +581,19 @@ class TogglReportsClient(TogglAPIClient):
         projects = dict()
         try:
             for item in super().get(endpoint='workspaces/{wid}/projects'.format(wid=wid)):
-                if item['cid'] not in projects:
-                    projects.update(
-                        {
-                            item['cid']: [
-                                item['name']
-                            ]
-                        }
-                    )
-                    continue
-                projects[item['cid']].append(item['name'])
+                try:
+                    if item['cid'] not in projects:
+                        projects.update(
+                            {
+                                item['cid']: [
+                                    item['name']
+                                ]
+                            }
+                        )
+                        continue
+                    projects[item['cid']].append(item['name'])
+                except KeyError:
+                    logging.warning(msg=yaml.dump(item))
         except TypeError:
             logging.debug(msg='it looks like you do not have any Toggl projects yet')
             return projects


### PR DESCRIPTION
With this change it will be possible to debug synchronization errors caused by missing `cid` keys in the list of projects returned from Toggl.

Example trace:

```
Traceback (most recent call last):
  File "toggl2pl", line 6, in <module>
  File "toggl2pl/__main__.py", line 245, in main
  File "toggl2pl/__main__.py", line 206, in run
  File "toggl2pl/__init__.py", line 105, in sync
  File "toggl2pl/__init__.py", line 584, in projects
KeyError: 'cid'
[13788] Failed to execute script toggl2pl
```