### PR TITLE
Restrict fetching of posts only to posts owned by the current Toggl account

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -8,7 +8,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python
       uses: actions/setup-python@v1
       with:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,7 @@
 variables:
   PACKAGE_ARCH: amd64
   PACKAGE_NAME: toggl2pl
-  PACKAGE_VERSION: 1.0.5
+  PACKAGE_VERSION: 1.0.6
 
 stages:
   - coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,6 @@ LABEL \
   description="Tool to simplify time entries export from Toggl into Project Laboratory" \
   maintainer="pa@yourserveradmin.com"
 
-RUN pip install toggl2pl==1.0.5
+RUN pip install toggl2pl==1.0.6
 
 CMD ["toggl2pl", "serve"]

--- a/README.md
+++ b/README.md
@@ -225,19 +225,13 @@ tool on this platform.
 * [x] document existing code, CLI flags and configuration options with Sphinx.
 * [x] freeze existing functional and tweak code to resolve regressions and improve
 quality.
+- [x] use Flask and move logic to centralized server to communicate with it by using
+HTTP API with a minimal set of required options. But, at the same time keep ability
+to use the module in server-less mode and directly communicate with Toggl and PL API.
+- [x] use Elasticsearch with Kibana to store and visualize data passed through server
+to provide flexible reports and analytic mechanisms (for each user and for teams).
 * [ ] unit tests and coverage reports for existing minimal set of features.
 
-The list above is incomplete, because there are too many ideas and features which
-can be implemented, for example:
-
-- extend the list of [supported APIs](#supported-apis) by [Clockify][clockify]
-API in order to provide an alternative to [Toggl][toggl].
-- use, for example, Flask, move logic to centralized server and communicate with
-it by using HTTP API with a minimal set of required options. But, at the same time
-keep ability to use the module in server-less mode and directly communicate with
-Toggl and PL API.
-- use Elasticsearch with Kibana to store and visualize data passed through server
-to provide flexible reports and analytic mechanisms (for each user and for teams).
 
 ## Internals
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ with GPG key.
 Example installation steps to execute on Linux:
 
 ```bash
-export TOGGL2PL_VERSION="1.0.5"
+export TOGGL2PL_VERSION="1.0.6"
 
 wget https://github.com/pa-yourserveradmin-com/toggl2pl/releases/download/v${TOGGL2PL_VERSION}/toggl2pl-${TOGGL2PL_VERSION}-linux-amd64.zip
 unzip toggl2pl-${TOGGL2PL_VERSION}-linux-amd64.zip

--- a/toggl2pl/__init__.py
+++ b/toggl2pl/__init__.py
@@ -502,6 +502,7 @@ class TogglReportsClient(TogglAPIClient):
         kwargs.update(
             {
                 'user_agent': self.user_agent,
+                'user_ids': self.me()['id'],
                 'workspace_id': wid
             }
         )


### PR DESCRIPTION
When account is a part of Toggl team and has `admin` privileges it can fetch details about tasks posted by all members. While this can be useful to review tasks at the same time this prevents posting of time to PL.

With this change only the current Toggl account posts will be fetched in case of working in team with `admin` privileges.